### PR TITLE
Fix error handling issues on R-devel

### DIFF
--- a/R/result.R
+++ b/R/result.R
@@ -23,13 +23,16 @@ get_result <- function(output, options) {
   ## Timeout?
   if (output$timeout) stop(make_error(output))
 
-  ## No output files? Some other (system?) error
-  if (! file.exists(res)) stop("child process crashed or was killed")
+  ## No output file and no error file? Some other (system?) error then
+  errorres <- paste0(res, ".error")
+  if (! file.exists(res) && ! file.exists(errorres)) {
+    stop("child process crashed or was killed")
+  }
 
   ## No error file? Then all is well, return the output
-  if (! file.exists(paste0(res, ".error"))) return(readRDS(res))
+  if (! file.exists(errorres)) return(readRDS(res))
 
-  err <- readRDS(paste0(res, ".error"))
+  err <- readRDS(errorres)
 
   if (err[[1]] == "error") {
     stop(err[[2]])


### PR DESCRIPTION
They are caused by a behavior change in saveRDS.
It always used to create the output file, but now
it does not do that any more, if the object to write
out cannot be successfully created.
See https://github.com/wch/r-source/commit/924582943706100e88a11d6bb0585d25779c91f5

Closes #37