### PR TITLE
Fix sigchld interference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache: packages
 r:
  - 3.1
  - 3.2
+ - 3.3
  - release
  - devel
  - oldrel

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Imports:
     utils
 Suggests:
     covr,
+    parallel,
     testthat,
     withr
 LinkingTo:

--- a/R/process-process.R
+++ b/R/process-process.R
@@ -110,12 +110,21 @@
 #' `$wait()` waits until the process finishes, or a timeout happens.
 #' Note that if the process never finishes, and the timeout is infinite
 #' (the default), then R will never regain control. It returns
-#' the process itself, invisibly.
+#' the process itself, invisibly. In some rare cases, `$wait()` might take
+#' a bit longer than specified to time out. This happens on Unix, when
+#' another package overwrites the processx SIGCHLD signal handler, after the
+#' processx process has started. One such package is parallel, if used
+#' with fork clusters, e.g. through [parallel::mcparallel()].
 #'
 #' `$get_pid()` returns the process id of the process.
 #'
 #' `$get_exit_status` returns the exit code of the process if it has
-#' finished and `NULL` otherwise.
+#' finished and `NULL` otherwise. On Unix, in some rare cases, the exit
+#' status might be `NA`. This happens if another package (or R itself)
+#' overwrites the processx SIGCHLD handler, after the processx process
+#' has started. In these cases processx cannot determine the real exit
+#' status of the process. One such package is parallel, if used with
+#' fork clusters, e.g. through the [parallel::mcparallel()] function.
 #'
 #' `$restart()` restarts a process. It returns the process itself.
 #'

--- a/man/process.Rd
+++ b/man/process.Rd
@@ -118,12 +118,21 @@ already finished/dead when \code{callr} tried to kill it).
 \code{$wait()} waits until the process finishes, or a timeout happens.
 Note that if the process never finishes, and the timeout is infinite
 (the default), then R will never regain control. It returns
-the process itself, invisibly.
+the process itself, invisibly. In some rare cases, \code{$wait()} might take
+a bit longer than specified to time out. This happens on Unix, when
+another package overwrites the processx SIGCHLD signal handler, after the
+processx process has started. One such package is parallel, if used
+with fork clusters, e.g. through \code{\link[parallel:mcparallel]{parallel::mcparallel()}}.
 
 \code{$get_pid()} returns the process id of the process.
 
 \code{$get_exit_status} returns the exit code of the process if it has
-finished and \code{NULL} otherwise.
+finished and \code{NULL} otherwise. On Unix, in some rare cases, the exit
+status might be \code{NA}. This happens if another package (or R itself)
+overwrites the processx SIGCHLD handler, after the processx process
+has started. In these cases processx cannot determine the real exit
+status of the process. One such package is parallel, if used with
+fork clusters, e.g. through the \code{\link[parallel:mcparallel]{parallel::mcparallel()}} function.
 
 \code{$restart()} restarts a process. It returns the process itself.
 

--- a/src/unix/callr-unix.h
+++ b/src/unix/callr-unix.h
@@ -40,7 +40,7 @@ callr__child_list_t *callr__child_find(pid_t pid);
 void callr__freelist_add(callr__child_list_t *ptr);
 void callr__freelist_free();
 
-void callr__collect_exit_status(SEXP status, int wstat);
+void callr__collect_exit_status(SEXP status, int retval, int wstat);
 
 int callr__nonblock_fcntl(int fd, int set);
 int callr__cloexec_fcntl(int fd, int set);

--- a/src/unix/callr.c
+++ b/src/unix/callr.c
@@ -473,7 +473,10 @@ SEXP callr_wait(SEXP status, SEXP timeout) {
        of SIGCHLD handler interference, i.e. if another package (like
        parallel) removes our signal handler. */
     ret = kill(pid, 0);
-    if (ret != 0) return ScalarLogical(1);
+    if (ret != 0) {
+      ret = 1;
+      goto cleanup;
+    }
 
     if (ctimeout >= 0) timeleft -= CALLR_INTERRUPT_INTERVAL;
   }
@@ -489,6 +492,7 @@ SEXP callr_wait(SEXP status, SEXP timeout) {
     error("callr wait with timeout error: %s", strerror(errno));
   }
 
+ cleanup:
   if (handle->waitpipe[0] >= 0) close(handle->waitpipe[0]);
   if (handle->waitpipe[1] >= 0) close(handle->waitpipe[1]);
   handle->waitpipe[0] = -1;

--- a/src/unix/childlist.c
+++ b/src/unix/childlist.c
@@ -89,6 +89,8 @@ SEXP callr__killem_all() {
       if (ret == 0) killed++;
     }
 
+    /* waitpid errors are ignored here... */
+
     R_ClearExternalPtr(status);
     /* The handle will be freed in the finalizer, otherwise there is
        a race condition here. */

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -2,4 +2,4 @@ library(testthat)
 library(callr)
 
 Sys.unsetenv("R_TESTS")
-test_check("callr")
+test_check("callr", reporter = "summary")

--- a/tests/testthat/test-sigchld.R
+++ b/tests/testthat/test-sigchld.R
@@ -8,14 +8,14 @@ test_that("is_alive()", {
 
   library(parallel)
 
-  px <- process$new("sleep", "1")
+  px <- process$new("sleep", "0.1")
   on.exit(try(px$kill(), silent = TRUE), add = TRUE)
 
-  p <- mcparallel(Sys.sleep(1))
-  q <- mcparallel(Sys.sleep(1))
+  p <- mcparallel(Sys.sleep(0.2))
+  q <- mcparallel(Sys.sleep(0.2))
   res <- mccollect(list(p, q))
   expect_false(px$is_alive())
-  expect_identical(px$get_exit_status(), NA_integer_)
+  expect_true(px$get_exit_status() %in% c(0L, NA_integer_))
 })
 
 test_that("finalizer", {
@@ -25,11 +25,11 @@ test_that("finalizer", {
 
   library(parallel)
 
-  px <- process$new("sleep", "1")
+  px <- process$new("sleep", "0.1")
   on.exit(try(px$kill(), silent = TRUE), add = TRUE)
 
-  p <- mcparallel(Sys.sleep(1))
-  q <- mcparallel(Sys.sleep(1))
+  p <- mcparallel(Sys.sleep(0.2))
+  q <- mcparallel(Sys.sleep(0.2))
   res <- mccollect(list(p, q))
   expect_error({ rm(px); gc() }, NA)
 })
@@ -41,13 +41,13 @@ test_that("get_exit_status", {
 
   library(parallel)
 
-  px <- process$new("sleep", "1")
+  px <- process$new("sleep", "0.1")
   on.exit(try(px$kill(), silent = TRUE), add = TRUE)
 
-  p <- mcparallel(Sys.sleep(1))
-  q <- mcparallel(Sys.sleep(1))
+  p <- mcparallel(Sys.sleep(0.2))
+  q <- mcparallel(Sys.sleep(0.2))
   res <- mccollect(list(p, q))
-  expect_identical(px$get_exit_status(), NA_integer_)
+  expect_true(px$get_exit_status() %in% c(0L, NA_integer_))
 })
 
 test_that("signal", {
@@ -57,14 +57,14 @@ test_that("signal", {
 
   library(parallel)
 
-  px <- process$new("sleep", "1")
+  px <- process$new("sleep", "0.1")
   on.exit(try(px$kill(), silent = TRUE), add = TRUE)
 
-  p <- mcparallel(Sys.sleep(1))
-  q <- mcparallel(Sys.sleep(1))
+  p <- mcparallel(Sys.sleep(0.2))
+  q <- mcparallel(Sys.sleep(0.2))
   res <- mccollect(list(p, q))
   expect_false(px$signal(2))            # SIGINT
-  expect_true(print(px$get_exit_status()) %in% c(0L, NA_integer_))
+  expect_true(px$get_exit_status() %in% c(0L, NA_integer_))
 })
 
 test_that("kill", {
@@ -74,14 +74,14 @@ test_that("kill", {
 
   library(parallel)
 
-  px <- process$new("sleep", "1")
+  px <- process$new("sleep", "0.1")
   on.exit(try(px$kill(), silent = TRUE), add = TRUE)
 
-  p <- mcparallel(Sys.sleep(1))
-  q <- mcparallel(Sys.sleep(1))
+  p <- mcparallel(Sys.sleep(0.2))
+  q <- mcparallel(Sys.sleep(0.2))
   res <- mccollect(list(p, q))
   expect_false(px$kill())
-  expect_identical(px$get_exit_status(), NA_integer_)
+  expect_true(px$get_exit_status() %in% c(0L, NA_integer_))
 })
 
 test_that("SIGCHLD handler", {
@@ -91,11 +91,11 @@ test_that("SIGCHLD handler", {
 
   library(parallel)
 
-  px <- process$new("sleep", "1")
+  px <- process$new("sleep", "0.1")
   on.exit(try(px$kill(), silent = TRUE), add = TRUE)
 
-  p <- mcparallel(Sys.sleep(1))
-  q <- mcparallel(Sys.sleep(1))
+  p <- mcparallel(Sys.sleep(0.2))
+  q <- mcparallel(Sys.sleep(0.2))
   res <- mccollect(list(p, q))
 
   expect_error({
@@ -104,5 +104,5 @@ test_that("SIGCHLD handler", {
     px2$wait(1)
   }, NA)
 
-  expect_identical(px$get_exit_status(), NA_integer_)
+  expect_true(px$get_exit_status() %in% c(0L, NA_integer_))
 })

--- a/tests/testthat/test-sigchld.R
+++ b/tests/testthat/test-sigchld.R
@@ -1,0 +1,108 @@
+
+context("SIGCHLD handler interference")
+
+test_that("is_alive()", {
+
+  skip_other_platforms("unix")
+  skip_on_cran()
+
+  library(parallel)
+
+  px <- process$new("sleep", "1")
+  on.exit(try(px$kill(), silent = TRUE), add = TRUE)
+
+  p <- mcparallel(Sys.sleep(1))
+  q <- mcparallel(Sys.sleep(1))
+  res <- mccollect(list(p, q))
+  expect_false(px$is_alive())
+  expect_identical(px$get_exit_status(), NA_integer_)
+})
+
+test_that("finalizer", {
+
+  skip_other_platforms("unix")
+  skip_on_cran()
+
+  library(parallel)
+
+  px <- process$new("sleep", "1")
+  on.exit(try(px$kill(), silent = TRUE), add = TRUE)
+
+  p <- mcparallel(Sys.sleep(1))
+  q <- mcparallel(Sys.sleep(1))
+  res <- mccollect(list(p, q))
+  expect_error({ rm(px); gc() }, NA)
+})
+
+test_that("get_exit_status", {
+
+  skip_other_platforms("unix")
+  skip_on_cran()
+
+  library(parallel)
+
+  px <- process$new("sleep", "1")
+  on.exit(try(px$kill(), silent = TRUE), add = TRUE)
+
+  p <- mcparallel(Sys.sleep(1))
+  q <- mcparallel(Sys.sleep(1))
+  res <- mccollect(list(p, q))
+  expect_identical(px$get_exit_status(), NA_integer_)
+})
+
+test_that("signal", {
+
+  skip_other_platforms("unix")
+  skip_on_cran()
+
+  library(parallel)
+
+  px <- process$new("sleep", "1")
+  on.exit(try(px$kill(), silent = TRUE), add = TRUE)
+
+  p <- mcparallel(Sys.sleep(1))
+  q <- mcparallel(Sys.sleep(1))
+  res <- mccollect(list(p, q))
+  expect_false(px$signal(2))            # SIGINT
+  expect_identical(px$get_exit_status(), NA_integer_)
+})
+
+test_that("kill", {
+
+  skip_other_platforms("unix")
+  skip_on_cran()
+
+  library(parallel)
+
+  px <- process$new("sleep", "1")
+  on.exit(try(px$kill(), silent = TRUE), add = TRUE)
+
+  p <- mcparallel(Sys.sleep(1))
+  q <- mcparallel(Sys.sleep(1))
+  res <- mccollect(list(p, q))
+  expect_false(px$kill())
+  expect_identical(px$get_exit_status(), NA_integer_)
+})
+
+test_that("SIGCHLD handler", {
+
+  skip_other_platforms("unix")
+  skip_on_cran()
+
+  library(parallel)
+
+  px <- process$new("sleep", "1")
+  on.exit(try(px$kill(), silent = TRUE), add = TRUE)
+
+  p <- mcparallel(Sys.sleep(1))
+  q <- mcparallel(Sys.sleep(1))
+  res <- mccollect(list(p, q))
+
+  expect_error({
+    px2 <- process$new("true")
+    on.exit(try(px2$kill(), silent = TRUE), add = TRUE)
+    px2$wait(1)
+  }, NA)
+
+  expect_identical(px$get_exit_status(), NA_integer_)
+})

--- a/tests/testthat/test-sigchld.R
+++ b/tests/testthat/test-sigchld.R
@@ -64,7 +64,7 @@ test_that("signal", {
   q <- mcparallel(Sys.sleep(1))
   res <- mccollect(list(p, q))
   expect_false(px$signal(2))            # SIGINT
-  expect_identical(px$get_exit_status(), NA_integer_)
+  expect_true(print(px$get_exit_status()) %in% c(0L, NA_integer_))
 })
 
 test_that("kill", {


### PR DESCRIPTION
Closes #46 

In the cases when our SIGCHLD signal handler was overwritten, we return `NA_integer_` as exit code.
