### PR TITLE
Set R_LIBS_USER environment variable in generated .Rprofile

### DIFF
--- a/R/setup.R
+++ b/R/setup.R
@@ -78,6 +78,10 @@ make_profile <- function(system, user, repos, libpath) {
   if (!is.null(libpath)) {
     cat(".libPaths(", deparse(libpath), ")\n", sep = "", file = profile,
         append = TRUE)
+
+    libpath_env <- encodeString(paste(libpath, collapse = .Platform$path.sep), quote = '"')
+    cat('Sys.setenv(R_LIBS_USER = ', libpath_env, ')\n', sep = "", file = profile,
+        append = TRUE)
   }
 
   profile

--- a/R/setup.R
+++ b/R/setup.R
@@ -80,7 +80,7 @@ make_profile <- function(system, user, repos, libpath) {
         append = TRUE)
 
     libpath_env <- encodeString(paste(libpath, collapse = .Platform$path.sep), quote = '"')
-    cat('Sys.setenv(R_LIBS_USER = ', libpath_env, ')\n', sep = "", file = profile,
+    cat("Sys.setenv(R_LIBS_USER = ", libpath_env, ")\n", sep = "", file = profile,
         append = TRUE)
   }
 


### PR DESCRIPTION
This seems necessary in some situations for `R CMD` in R <= 3.3, e.g. when the created process starts another subprocess that requires properly set up library paths. It worked in an interactive debug session on Travis CI, I'm using it now from _tic_ to see if it has the desired effect. Will post updates here.

No idea how to test this, it's really an integration test that perhaps belongs in _rcmdcheck_?

Closes #55.