### PR TITLE
Retain names of the 'repos' option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ Roxygen: list(markdown = TRUE)
 Imports:
     processx (>= 3.1.0.9004),
     R6,
-    stats,
     utils
 Suggests:
     covr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Roxygen: list(markdown = TRUE)
 Imports:
     processx (>= 3.1.0.9004),
     R6,
+    stats,
     utils
 Suggests:
     covr,

--- a/R/check.R
+++ b/R/check.R
@@ -24,7 +24,9 @@ convert_and_check_my_args <- function(options) {
   ## Conversions
   options <- within(options, {
     if (has("libpath")) libpath <- as.character(libpath)
-    if (has("repos")) repos <- as.character(repos)
+    if (has("repos")) {
+      repos <- stats::setNames(as.character(repos), names(repos))
+    }
     if (has("stdout") && !is.null(stdout)) {
       stdout <- as.character(stdout)
     }

--- a/R/check.R
+++ b/R/check.R
@@ -24,9 +24,7 @@ convert_and_check_my_args <- function(options) {
   ## Conversions
   options <- within(options, {
     if (has("libpath")) libpath <- as.character(libpath)
-    if (has("repos")) {
-      repos <- stats::setNames(as.character(repos), names(repos))
-    }
+    if (has("repos")) stopifnot(is.character(repos))
     if (has("stdout") && !is.null(stdout)) {
       stdout <- as.character(stdout)
     }

--- a/tests/testthat/test-presets.R
+++ b/tests/testthat/test-presets.R
@@ -19,7 +19,7 @@ test_that("r", {
 test_that("r_vanilla", {
   expect_equal(
     r_vanilla(function() getOption("repos"), libpath = .libPaths()),
-    "@CRAN@"
+    c(CRAN = "@CRAN@")
   )
 })
 

--- a/tests/testthat/test-presets.R
+++ b/tests/testthat/test-presets.R
@@ -48,3 +48,13 @@ test_that("R_LIBS_SITE is set properly", {
 
   expect_true(lib %in% res)
 })
+
+## https://github.com/r-lib/callr/issues/66
+test_that("names of getOption('repos') are preserved", {
+  repos <- withr::with_options(
+    list(repos = c(foo = "bar")),
+    callr::r(function() getOption("repos"))
+  )
+  expect_false(is.null(names(repos)))
+  expect_identical("foo", names(repos)[[1]])
+})


### PR DESCRIPTION
Fixes #66 Names of the `repos` option are being stripped

~The test failure is the same that is already present on master FYI.~ *updated: maybe all ok there*