### PR TITLE
Use errors.R in subprocess

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /src/tools/px.exe
 /src/tools/px.dSYM
 /src/callr.so
+/inst/env.rds

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: callr
 Title: Call R from R
-Version: 3.2.0.9000
+Version: 3.2.0.9001
 Authors@R: c(
     person("Gábor", "Csárdi", role = c("aut", "cre", "cph"),
            email = "csardi.gabor@gmail.com",

--- a/R/errors.R
+++ b/R/errors.R
@@ -18,9 +18,16 @@
 #   more meaningful for the users, while also keeping the lower level
 #   details in the error object. (So in `.Last.error` as well.)
 # - `.Last.error` always includes a stack trace. (The stack trace is
-#   common for the whole error hierarchy.)
+#   common for the whole error hierarchy.) The trace is accessible within
+#   the error, e.g. `.Last.error$trace`. The trace of the last error is
+#   also at `.Last.error.trace`.
+# - Can merge errors and traces across multiple processes.
+# - Pretty-print errors and traces, if the crayon package is loaded.
+# - Automatically hides uninformative parts of the stack trace when
+#   printing.
 #
 # ## API
+#
 # ```
 # new_cond(..., call. = TRUE, domain = NULL)
 # new_error(..., call. = TRUE, domain = NULL)

--- a/R/eval-bg.R
+++ b/R/eval-bg.R
@@ -36,5 +36,6 @@ r_bg <- function(func, args = list(), libpath = .libPaths(),
 
   options <- as.list(environment())
   options$extra  <- list(...)
+  options$load_hook <- default_load_hook()
   r_process$new(options = options)
 }

--- a/R/hook.R
+++ b/R/hook.R
@@ -1,8 +1,13 @@
 
 common_hook <- function() {
+  envfile <- normalizePath(system.file("env.rds", package = "callr"))
   substitute({
+    # This should not happen in a new R session, but just to be safe
+    while ("tools:callr" %in% search()) detach("tools:callr")
+    env <- readRDS(`__envfile__`)
+    attach(env, pos = length(search()), name = "tools:callr")
     options(error = function() invokeRestart("abort"))
-  })
+  }, list("__envfile__" = envfile))
 }
 
 default_load_hook <- function(user_hook = NULL) {

--- a/R/hook.R
+++ b/R/hook.R
@@ -5,7 +5,7 @@ common_hook <- function() {
     # This should not happen in a new R session, but just to be safe
     while ("tools:callr" %in% search()) detach("tools:callr")
     env <- readRDS(`__envfile__`)
-    attach(env, pos = length(search()), name = "tools:callr")
+    do.call("attach", list(env, pos = length(search()), name = "tools:callr"))
     options(error = function() invokeRestart("abort"))
   }, list("__envfile__" = envfile))
 }

--- a/R/package.R
+++ b/R/package.R
@@ -11,3 +11,13 @@ NULL
 
 ## R CMD check workaround
 dummy_r6 <- function() R6::R6Class
+
+## We save this as an RDS, so it can be loaded quickly
+env <- new.env(parent = emptyenv())
+env$`__callr_data__` <- new.env(parent = emptyenv())
+env$`__callr_data__`$err <- err
+saveRDS(
+  env,
+  file = file.path(system.file(package = "callr"), "env.rds"),
+  version = 2)
+rm(env)

--- a/R/result.R
+++ b/R/result.R
@@ -65,7 +65,8 @@ get_result <- function(output, options) {
 
   if (err[[1]] == "error") {
     err[[2]]$message <- err[[2]]$message %||% "interrupt"
-    throw(err[[2]])
+    msg <- paste0("callr subprocess failed: ", conditionMessage(err[[2]]))
+    throw(new_error(msg), parent = err[[2]])
 
   } else if (err[[1]] == "stack") {
     myerr <- structure(

--- a/R/script.R
+++ b/R/script.R
@@ -8,6 +8,8 @@ make_vanilla_script_expr <- function(expr_file, res, error,
     substitute({
       # TODO: get rid of magic number 9
       capture.output(assign(".Traceback", traceback(9), envir = baseenv()))
+      err <- as.environment("tools:callr")$`__callr_data__`$err
+      e <- err$add_trace_back(e)
       saveRDS(list("error", e), file = paste0(`__res__`, ".error")) },
       list(`__res__` = res)
     )

--- a/R/script.R
+++ b/R/script.R
@@ -19,7 +19,9 @@ make_vanilla_script_expr <- function(expr_file, res, error,
         calls,
         function(x) length(x) >= 1 && identical(x[[1]], quote(do.call)),
         logical(1)))[1]
-      if (!is.na(dcframe)) e$ignore <- list(c(1, dcframe + 1L))
+      if (!is.na(dcframe)) e$`_ignore` <- list(c(1, dcframe + 1L))
+      e$`_pid` <- Sys.getpid()
+      e$`_timestamp` <- Sys.time()
       err <- as.environment("tools:callr")$`__callr_data__`$err
       e <- err$add_trace_back(e)
       saveRDS(list("error", e), file = paste0(`__res__`, ".error")) },

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -15,8 +15,7 @@ test_that("error object is passed", {
     r(function() 1 + "A", error = "error"),
     error = function(e) err <<- e
   )
-  expect_true("call" %in% names(err))
-  expect_true(inherits(err, "error"))
+  expect_true(inherits(err, "rlib_error"))
   gc()
 })
 
@@ -49,8 +48,7 @@ test_that("error behavior can be set using option", {
       error = function(e) err <<- e
     )
   })
-  expect_true("call" %in% names(err))
-  expect_true(inherits(err, "error"))
+  expect_true(inherits(err, "rlib_error"))
 
   err <- NULL
   withr::with_options(c(callr.error = "stack"), {

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -70,3 +70,171 @@ test_that("error behavior can be set using option", {
   expect_equal(length(err$stack), 3)
   gc()
 })
+
+test_that("parent errors", {
+  withr::local_options(list("callr.error" = "error"))
+  err <- tryCatch(
+    r(function() 1 + "A"),
+    error = function(e) e)
+
+  expect_s3_class(err, "rlib_error")
+  expect_s3_class(err$parent, "simpleError")
+  expect_match(
+    conditionMessage(err),
+    "callr subprocess failed: non-numeric argument")
+  expect_match(
+    conditionMessage(err$parent),
+    "non-numeric argument")
+})
+
+test_that("parent errors, another level", {
+  withr::local_options(list("callr.error" = "error"))
+  err <- tryCatch(
+    callr::r(function() {
+      withr::local_options(list("callr.error" = "error"))
+      callr::r(function() 1 + "A")
+    }),
+    error = function(e) e)
+
+  expect_s3_class(err, "rlib_error")
+  expect_s3_class(err$parent, "rlib_error")
+  expect_s3_class(err$parent$parent, "simpleError")
+
+  expect_match(
+    conditionMessage(err),
+    "callr subprocess failed: callr subprocess failed: non-numeric")
+  expect_match(
+    conditionMessage(err$parent),
+    "callr subprocess failed: non-numeric argument")
+  expect_match(
+    conditionMessage(err$parent$parent),
+    "non-numeric argument")
+})
+
+test_that("error traces are merged", {
+  skip_on_cran()
+
+  sf <- tempfile(fileext = ".R")
+  op <- sub("\\.R$", ".rds", sf)
+  so <- paste0(sf, "out")
+  se <- paste0(sf, "err")
+  on.exit(unlink(c(sf, op, so, se), recursive = TRUE), add = TRUE)
+
+  expr <- substitute({
+    h <- function() callr::r(function() 1 + "a")
+    options(rlib_error_handler = function(c) {
+      saveRDS(c, file = `__op__`)
+      # quit after the first, because the other one is caught here as well
+      q()
+    })
+    h()
+  }, list("__op__" = op))
+
+  cat(deparse(expr), file = sf, sep = "\n")
+
+  callr::rscript(sf, stdout = so, stderr = se)
+
+  cond <- readRDS(op)
+
+  expect_s3_class(cond, "rlib_error")
+  expect_s3_class(cond$parent, "error")
+  expect_s3_class(cond$trace, "rlib_trace")
+
+  expect_equal(length(cond$trace$nframe), 2)
+  expect_true(cond$trace$nframe[1] < cond$trace$nframe[2])
+  expect_match(cond$trace$messages[[1]], "subprocess failed: non-numeric")
+  expect_match(cond$trace$messages[[2]], "non-numeric argument")
+})
+
+test_that("errors in r_bg() are merged", {
+  withr::local_options(list("callr.error" = "error"))
+
+  p <- r_bg(function() 1 + "A")
+  on.exit(p$kill(), add = TRUE)
+  p$wait(2000)
+
+  err <- tryCatch(
+    p$get_result(),
+    error = function(e) e)
+
+  expect_s3_class(err, "rlib_error")
+  expect_s3_class(err$parent, "simpleError")
+  expect_match(
+    conditionMessage(err),
+    "callr subprocess failed: non-numeric argument")
+  expect_match(
+    conditionMessage(err$parent),
+    "non-numeric argument")
+})
+
+test_that("errors in r_process are merged", {
+  withr::local_options(list("callr.error" = "error"))
+
+  opts <- r_process_options(func = function() 1 + "A")
+  p <- r_process$new(opts)
+  on.exit(p$kill(), add = TRUE)
+  p$wait(2000)
+
+  err <- tryCatch(
+    p$get_result(),
+    error = function(e) e)
+
+  expect_s3_class(err, "rlib_error")
+  expect_s3_class(err$parent, "simpleError")
+  expect_match(
+    conditionMessage(err),
+    "callr subprocess failed: non-numeric argument")
+  expect_match(
+    conditionMessage(err$parent),
+    "non-numeric argument")
+})
+
+test_that("errors in r_session$run() are merged", {
+  rs <- r_session$new()
+  on.exit(rs$kill(), add = TRUE)
+
+  err1 <- tryCatch(
+    rs$run(function() 1 + "A"),
+    error = function(e) e)
+  err2 <- tryCatch(
+    rs$run(function() 1 + "A"),
+    error = function(e) e)
+  err <- list(err1, err2)
+
+  for (i in seq_along(err)) {
+    expect_s3_class(err[[i]], "rlib_error")
+    expect_s3_class(err[[i]]$parent, "simpleError")
+    expect_match(
+      conditionMessage(err[[i]]),
+      "callr subprocess failed: non-numeric argument")
+    expect_match(
+      conditionMessage(err[[i]]$parent),
+      "non-numeric argument")
+  }
+})
+
+test_that("errors in r_session$call() are merged", {
+  rs <- r_session$new()
+  on.exit(rs$kill(), add = TRUE)
+
+  rs$call(function() 1 + "A")
+  rs$poll_process(2000)
+  err1 <- rs$read()$error
+
+  rs$call(function() 1 + "A")
+  rs$poll_process(2000)
+  err2 <- rs$read()$error
+
+  err <- list(err1, err2)
+
+  for (i in seq_along(err)) {
+    expect_s3_class(err[[i]], "rlib_error")
+    expect_s3_class(err[[i]]$parent, "simpleError")
+    expect_match(
+      conditionMessage(err[[i]]),
+      "callr subprocess failed: non-numeric argument")
+    expect_match(
+      conditionMessage(err[[i]]$parent),
+      "non-numeric argument")
+  }
+})

--- a/tests/testthat/test-r-session.R
+++ b/tests/testthat/test-r-session.R
@@ -109,7 +109,8 @@ test_that("interrupt", {
   rs$interrupt()
   rs$poll_process(1000)
   res <- rs$read()
-  expect_s3_class(res$error, "interrupt")
+  expect_s3_class(res$error, "rlib_error")
+  expect_s3_class(res$error$parent, "interrupt")
   rs$close()
 })
 


### PR DESCRIPTION
This gives us 
- `.Last.error`
- `.Last.error.trace`
- Having remote errors as parent errors.
- A single stack trace for both (or multiple in general) processes.

Note that `errors.R` is standalone, so we don't require a newer processx package.