### PR TITLE
Merge pull request #123 from jdblischak/error-env-file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # callr development version
 
+* callr functions fail early if environment file is missing (#123, @jdblischak)
+
 # callr 3.4.0
 
 * All callr functions and background processes properly clean up

--- a/R/hook.R
+++ b/R/hook.R
@@ -33,6 +33,13 @@ common_hook <- function() {
 }
 
 default_load_hook <- function(user_hook = NULL) {
+
+  if (!file.exists(env_file))
+    stop(
+      "Unable to find environment file in temporary directory.",
+      " Try restarting R session."
+    )
+
   hook <- common_hook()
 
   if (!is.null(user_hook)) {

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -256,3 +256,16 @@ test_that("child error is not modified", {
   )
   expect_null(err$parent$error$trace)
 })
+
+test_that("early error for missing environment file", {
+
+  f <- function() {
+    file.remove(callr:::env_file)
+    callr::r(function() 1 + 1)
+  }
+
+  expect_error(
+    callr::r(f),
+    "Unable to find environment file"
+  )
+})


### PR DESCRIPTION
To facilitate debugging similar to my experience in #121 (where my code accidentally deleted the temporary directory and then recreated it), I added an early failure if the environment file is missing.

