### PR TITLE
More principled passing of library path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
 * All callr functions and background processes properly clean up
   temporary files now (#104).
 
+* callr now uses a more principled setup for the library path, and
+  restores the related environment variables in the child process.
+  This is a **breaking change** if you relied on having the library set
+  in a `system()` subprocess of the callr subprocess (#114).
+
 * Better printing of `rlang_error`s that happened in the subprocess.
 
 * callr now loads `.Rprofile` files from the current working directory

--- a/R/hook.R
+++ b/R/hook.R
@@ -9,6 +9,26 @@ common_hook <- function() {
     data$pxlib <- data$load_client_lib(data$sofile)
     options(error = function() invokeRestart("abort"))
     rm(list = c("data", "env"))
+
+    lapply(
+      c("R_ENVIRON", "R_ENVIRON_USER", "R_PROFILE", "R_PROFILE_USER",
+        "R_LIBS", "R_LIBS_USER", "R_LIBS_SITE"),
+      function(var) {
+        bakvar <- paste0("CALLR_", var, "_BAK")
+        val <- Sys.getenv(bakvar, NA_character_)
+        if (!is.na(val)) {
+          do.call("Sys.setenv", structure(list(val), names = var))
+        } else {
+          Sys.unsetenv(var)
+        }
+        Sys.unsetenv(bakvar)
+      }
+    )
+
+    Sys.unsetenv("CALLR_CHILD_R_LIBS")
+    Sys.unsetenv("CALLR_CHILD_R_LIBS_SITE")
+    Sys.unsetenv("CALLR_CHILD_R_LIBS_USER")
+
   }, list("__envfile__" = env_file))
 }
 

--- a/R/setup.R
+++ b/R/setup.R
@@ -33,12 +33,22 @@ setup_context <- function(options) {
     envs <- make_environ(profiles, libpath)
     tmp_files <- c(tmp_files, envs)
 
+    ## environment variables
+
+    ## First, save these, so we can restore them exactly in the subprocess,
+    ## and sub-subprocesses are not affected by our workarounds
+    save_env <- c("R_ENVIRON", "R_ENVIRON_USER", "R_PROFILE",
+                  "R_PROFILE_USER", "R_LIBS", "R_LIBS_USER", "R_LIBS_SITE")
+    save_set <- save_env %in% names(Sys.getenv())
+    save_nms <- paste0("CALLR_", save_env, "_BAK")
+    env[save_nms[save_set]] <- Sys.getenv(save_env[save_set])
+    env <- env[setdiff(names(env), save_nms[!save_set])]
+
     if (is.na(env["R_ENVIRON"])) env["R_ENVIRON"] <- envs[[1]]
     if (is.na(env["R_ENVIRON_USER"])) env["R_ENVIRON_USER"] <- envs[[2]]
     if (is.na(env["R_PROFILE"])) env["R_PROFILE"] <- profiles[[1]]
     if (is.na(env["R_PROFILE_USER"])) env["R_PROFILE_USER"] <- profiles[[2]]
 
-    ## environment variables
     if (is.na(env["R_LIBS"])) env["R_LIBS"] <- make_path(libpath)
     if (is.na(env["R_LIBS_USER"])) env["R_LIBS_USER"] <- make_path(libpath)
     if (is.na(env["R_LIBS_SITE"])) env["R_LIBS_SITE"] <- make_path(.Library.site)

--- a/tests/testthat/fixtures/csomag/DESCRIPTION
+++ b/tests/testthat/fixtures/csomag/DESCRIPTION
@@ -1,0 +1,12 @@
+Package: csomag
+Title: Test Package for 'callr'
+Version: 0.0.0.9999
+Authors@R: c(
+    person("Gábor", "Csárdi", role = c("aut", "cre", "cph"),
+           email = "csardi.gabor@gmail.com",
+	   comment = c(ORCID = "0000-0001-7098-9676")))
+Description: Test package for 'callr'.
+License: MIT + file LICENSE
+LazyData: true
+Encoding: UTF-8
+Language: en-US

--- a/tests/testthat/fixtures/csomag/R/libpath.R
+++ b/tests/testthat/fixtures/csomag/R/libpath.R
@@ -1,0 +1,19 @@
+
+file_from_env <- function(var) {
+  if (file.exists(f <- Sys.getenv(var))) readLines(f)
+}
+
+if (Sys.getenv("CALLR_DUMP_HERE") != "") {
+  saveRDS(
+    list(
+      env = Sys.getenv(),
+      libpaths = .libPaths(),
+      search = search(),
+      R_ENVIRON = file_from_env("R_ENVIRON"),
+      R_ENVIRON_USER = file_from_env("R_ENVIRON_USER"),
+      R_PROFILE = file_from_env("R_PROFILE"),
+      R_PROFILE_USER = file_from_env("R_PROFILE_USER")
+    ),
+    file = Sys.getenv("CALLR_DUMP_HERE")
+  )
+}

--- a/tests/testthat/test-libpath.R
+++ b/tests/testthat/test-libpath.R
@@ -203,6 +203,7 @@ test_that("libpath in system, in R CMD INSTALL", {
   }, list(csomag, tmplib, dump))
 
   data <- readRDS(dump)
+  if (!interactive()) print(data)
   ## We test the basename, in case a normalizePath makes dirnames differ
   expect_true(basename(tmplib) %in% basename(data$libpaths))
 

--- a/tests/testthat/test-libpath.R
+++ b/tests/testthat/test-libpath.R
@@ -188,6 +188,8 @@ test_that("libpath in system, if subprocess changes R_LIBS #2", {
 })
 
 test_that("libpath in system, in R CMD INSTALL", {
+  skip_on_cran()
+
   csomag <- test_path("fixtures","csomag")
   tmplib <- tempfile()
   dir.create(tmplib)

--- a/tests/testthat/test-libpath.R
+++ b/tests/testthat/test-libpath.R
@@ -90,7 +90,8 @@ test_that("libpath in system, R_LIBS in .Renviron", {
 
   withr::local_libpaths(tmpdrop, action = "prefix")
 
-  test_paths(tmpdrop, tmpkeep)
+  # Since we add tmpdrop in .Renviron, it will only be dropped by --vanilla
+  test_paths(tmpdrop, tmpkeep, system_drop = NULL)
 
   ## To close FDs
   gc()
@@ -107,7 +108,8 @@ test_that("libpath in system, R_LIBS", {
 
   withr::local_libpaths(tmpdrop, action = "prefix")
 
-  test_paths(tmpdrop, tmpkeep)
+  # R_LIBS is used by both R and R --vanilla, so it will not be dropped
+  test_paths(tmpdrop, tmpkeep, system_drop = NULL, system_vanilla_drop = NULL)
 
   ## To close FDs
   gc()
@@ -124,7 +126,8 @@ test_that("libpath in system, R_LIBS and .Renviron", {
 
   withr::local_libpaths(tmpdrop, action = "prefix")
 
-  test_paths(tmpdrop, tmpkeep)
+  # R_LIBS is used by both R and R --vanilla, so it will not be dropped
+  test_paths(tmpdrop, tmpkeep, system_drop = NULL, system_vanilla_drop = NULL)
 
   ## To close FDs
   gc()
@@ -147,6 +150,59 @@ test_that("libpath in system, if subprocess changes R_LIBS", {
 
   out <- callr::r(f, list(rbin = rbin, new = tmpkeep))
   expect_true(any(grepl(basename(normalizePath(tmpkeep)), out)))
+
+  ## Close FDs
+  gc()
+})
+
+test_that("libpath in system, if subprocess changes R_LIBS #2", {
+
+  if (.Platform$OS.type != "unix") skip("Unix only")
+
+  dir.create(tmpkeep <- tempfile("keep"))
+  on.exit(unlink(tmpkeep, recursive = TRUE), add  = TRUE)
+
+  rbin <- setup_r_binary_and_args(list())$bin
+
+  f <- function(rbin, new) {
+    Sys.setenv(R_LIBS = new)
+    Sys.setenv(R_ENVIRON_USER = "no_such_file")
+    env <- paste0("R_LIBS=", shQuote(new))
+    tmp <- tempfile()
+    on.exit(unlink(tmp), add = TRUE)
+    system2(
+      rbin,
+      c("--no-site-file", "--no-init-file", "--no-save",
+        "--no-restore", "--slave", "-e", "'.libPaths()'"),
+      env = env,
+      stdout = tmp
+    )
+    readLines(tmp)
+  }
+
+  out <- callr::r(f, list(rbin = rbin, new = tmpkeep))
+  expect_true(any(grepl(basename(normalizePath(tmpkeep)), out)))
+
+  ## Close FDs
+  gc()
+})
+
+test_that("libpath in system, in R CMD INSTALL", {
+  csomag <- test_path("fixtures","csomag")
+  tmplib <- tempfile()
+  dir.create(tmplib)
+  on.exit(unlink(tmplib, recursive = TRUE), add = TRUE)
+  dump <- tempfile(fileext = ".rds")
+  on.exit(unlink(dump), add = TRUE)
+
+  out <- callr::r(function(pkg, lib, savefile) {
+    Sys.setenv(CALLR_DUMP_HERE = savefile)
+    install.packages(pkg, lib = lib, repos = NULL, type = "source")
+  }, list(csomag, tmplib, dump))
+
+  data <- readRDS(dump)
+  ## We test the basename, in case a normalizePath makes dirnames differ
+  expect_true(basename(tmplib) %in% basename(data$libpaths))
 
   ## Close FDs
   gc()

--- a/tests/testthat/test-libpath.R
+++ b/tests/testthat/test-libpath.R
@@ -199,11 +199,13 @@ test_that("libpath in system, in R CMD INSTALL", {
 
   out <- callr::r(function(pkg, lib, savefile) {
     Sys.setenv(CALLR_DUMP_HERE = savefile)
+    ## We need to do this, otherwise install.packages() only keeps the
+    ## first library
+    Sys.unsetenv("_R_CHECK_INSTALL_DEPENDS_")
     install.packages(pkg, lib = lib, repos = NULL, type = "source")
   }, list(csomag, tmplib, dump))
 
   data <- readRDS(dump)
-  if (!interactive()) print(data)
   ## We test the basename, in case a normalizePath makes dirnames differ
   expect_true(basename(tmplib) %in% basename(data$libpaths))
 


### PR DESCRIPTION
Now in the child process we restore the configuration
of the main process.

Closes #114.