### PR TITLE
Require minimum of cli 1.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     R6,
     utils
 Suggests:
-    cli,
+    cli (>= 1.1.0),
     covr,
     ps,
     rprojroot,


### PR DESCRIPTION
`col_red()` was added in cli 1.1.0

https://github.com/r-lib/processx/search?q=col_red
https://github.com/r-lib/cli/commit/bd86957597f76c720ce8ddc46b7ed377b2af2532
https://github.com/r-lib/cli/blob/main/NEWS.md#cli-110
https://github.com/r-lib/processx/pull/320