### PR TITLE
Hotfix get running time

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # callr (development version)
 
+* The `r_session$get_running_time()` method now returns the correct
+  values, as documented (#241, @djnavarro).
+
 # callr 3.7.3
 
 * Errors from callr now include the standard output (in `$stdout`) and

--- a/R/r-session.R
+++ b/R/r-session.R
@@ -539,9 +539,10 @@ rs_get_state <- function(self, private) {
 rs_get_running_time <- function(self, private) {
   now <- Sys.time()
   finished <- private$state == "finished"
+  idle <- private$state == "idle"
   no_uptime <- as.difftime(NA_real_, units = "secs")
   c(total = if (finished) no_uptime else now - private$started_at,
-    current = now - private$fun_started_at)
+    current = if (finished | idle) no_uptime else now - private$fun_started_at)
 }
 
 rs_poll_process <- function(self, private, timeout) {

--- a/R/r-session.R
+++ b/R/r-session.R
@@ -539,7 +539,8 @@ rs_get_state <- function(self, private) {
 rs_get_running_time <- function(self, private) {
   now <- Sys.time()
   finished <- private$state == "finished"
-  c(total = if (finished) now - private$started_at else as.POSIXct(NA),
+  no_uptime <- as.difftime(NA_real_, units = "secs")
+  c(total = if (finished) no_uptime else now - private$started_at,
     current = now - private$fun_started_at)
 }
 

--- a/R/r-session.R
+++ b/R/r-session.R
@@ -540,9 +540,9 @@ rs_get_running_time <- function(self, private) {
   now <- Sys.time()
   finished <- private$state == "finished"
   idle <- private$state == "idle"
-  no_uptime <- as.difftime(NA_real_, units = "secs")
-  c(total = if (finished) no_uptime else now - private$started_at,
-    current = if (finished | idle) no_uptime else now - private$fun_started_at)
+  missing <- as.difftime(NA_real_, units = "secs")
+  c(total = now - private$started_at,
+    current = if (finished | idle) missing else now - private$fun_started_at)
 }
 
 rs_poll_process <- function(self, private, timeout) {

--- a/tests/testthat/test-r-session.R
+++ b/tests/testthat/test-r-session.R
@@ -25,6 +25,19 @@ test_that("regular use", {
   expect_equal(res$result, 84)
   expect_equal(rs$get_state(), "idle")
 
+  ## While session is idle the current call running time is NA
+  rs$call(function() 42)
+  expect_equal(
+    is.na(rs$get_running_time()),
+    c(total = FALSE, current = FALSE)
+  )
+  res <- read_next(rs)
+  expect_equal(
+    is.na(rs$get_running_time()),
+    c(total = FALSE, current = TRUE)
+  )
+  expect_s3_class(rs$get_running_time(), "difftime")
+
   ## Close
   rs$close()
   expect_equal(rs$get_state(), "finished")


### PR DESCRIPTION
This should fix #241. The `get_running_time()` method should now always return a difftime, which will have `NA` as the second value if there is no current computation running. 

I think that aligns with the existing description in the documentation so I didn't touch the docs at all, but I did add a couple of tests. Hopefully that fixes the issue! 