### PR TITLE
Run init function of client lib

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: callr
 Title: Call R from R
-Version: 3.7.3.9000
+Version: 3.7.3.9001
 Authors@R: c(
     person("Gábor", "Csárdi", , "csardi.gabor@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-7098-9676")),

--- a/R/load-client.R
+++ b/R/load-client.R
@@ -58,6 +58,7 @@ load_client_lib <- function(sofile = NULL, pxdir = NULL) {
 
   env <- new.env(parent = emptyenv())
   env$.path <- sofile
+  env$.lib <- lib
 
   mycall <- .Call
 

--- a/tests/testthat/test-load-client.R
+++ b/tests/testthat/test-load-client.R
@@ -90,3 +90,20 @@ test_that("set_stdout_file, set_setderr_file", {
   ret <- callr::r(do)  
   expect_equal(ret, c("this is output", "this is error"))
 })
+
+test_that("init function of client lib is run", {
+  pxlib <- r(function() {
+    as.environment("tools:callr")$`__callr_data__`$pxlib
+  })
+
+  # File name should be `client.SOEXT` so that R can match the init
+  # function from the name
+  expect_true(grepl("^client\\.", basename(pxlib$.path)))
+
+  # In case R removes the `dynamicLookup` field
+  skip_on_cran()
+
+  # Should be `FALSE` since processx disables dynamic lookup in the
+  # init function
+  expect_false(unclass(pxlib$.lib)$dynamicLookup)
+})


### PR DESCRIPTION
The client library needs to be named `client.so` or `client.dll` because R finds the `R_init_client` function from the file name.

This PR moves the metadata encoded in the name to the directory structure, e.g. `/tmp/RtmpUipw23/callr-client--7fc6a31.so` becomes `/tmp/RtmpMeE1ZE/callr//7fc6a31/client.so`.