### PR TITLE
Don't unload client library if potentially shared

### DIFF
--- a/R/load-client.R
+++ b/R/load-client.R
@@ -23,9 +23,14 @@ load_client_lib <- function(sofile = NULL, pxdir = NULL) {
     stop("Cannot find client file")
   }
 
+  # We set this to `FALSE` if we load the library from the processx
+  # install path since that library might be shared (e.g. in tests)
+  need_cleanup <- TRUE
+
   if (is.null(sofile)) {
     sofile <- sofile_in_processx()
     lib <- dyn.load(sofile)
+    need_cleanup <- FALSE
   } else {
     # This is the usual case, first we try loading it from the
     # temporary directory. If that fails (e.g. noexec), then
@@ -35,7 +40,10 @@ load_client_lib <- function(sofile = NULL, pxdir = NULL) {
     if (inherits(lib, "error")) {
       sofile <- sofile_in_processx()
       tryCatch(
-        lib <- dyn.load(sofile),
+        expr = {
+          lib <- dyn.load(sofile)
+          need_cleanup <- FALSE
+        },
 	error = function(err2) {
 	  err2$message <- err2$message <- paste0(" after ", lib$message)
 	  stop(err2)
@@ -45,7 +53,9 @@ load_client_lib <- function(sofile = NULL, pxdir = NULL) {
   }
 
   # cleanup if setup fails
-  on.exit(try(dyn.unload(sofile), silent = TRUE), add = TRUE)
+  if (need_cleanup) {
+    on.exit(try(dyn.unload(sofile), silent = TRUE), add = TRUE)
+  }
 
   sym_encode <- getNativeSymbolInfo("processx_base64_encode", lib)
   sym_decode <- getNativeSymbolInfo("processx_base64_decode", lib)
@@ -100,7 +110,9 @@ load_client_lib <- function(sofile = NULL, pxdir = NULL) {
   }
 
   env$.finalize <- function() {
-    dyn.unload(env$.path)
+    if (need_cleanup) {
+      dyn.unload(env$.path)
+    }
     rm(list = ls(env, all.names = TRUE), envir = env)
   }
 


### PR DESCRIPTION
I'm getting random errors on gc during tests because the finaliser of the library wrapper unloads the library even when potentially used by other instances:

```r
# OK
load_client_lib()
gc()
load_client_lib()
gc()
load_client_lib()
gc()

# FAIL
load_client_lib()
load_client_lib()
gc()
load_client_lib()
gc()
#> Error in dyn.unload(env$.path) :
#> shared object '/Users/lionel/R/Library/4.4-aarch64/processx/libs//client.so' was not loaded
```

To fix these errors, this PR proposes to only unload the library if a non-default `sofile` is used. Alternatively we could catch and discard any errors, but it seems cleaner to just preserve the lib in memory since it's shared. It also doesn't seem worth it to count the loads/unloads.