### PR TITLE
Update stdout and stderr argument docs

### DIFF
--- a/R/eval.R
+++ b/R/eval.R
@@ -44,8 +44,10 @@
 #'   then the commands are not echoed and will not be shown
 #'   in the standard output. Also note that you need to call `print()`
 #'   explicitly to show the output of the command(s).
-#'   IF `NULL` (the default), then standard output is not returned, but
+#'   IF `NULL`, then standard output is not returned, but
 #'   it is recorded and included in the error object if an error happens.
+#'   Various special values for this argument such as `"|"` are explained
+#'   in the `stdout` argument of [processx::process].
 #' @param stderr The name of the file the standard error of
 #'   the child R process will be written to.
 #'   In particular `message()` sends output to the standard
@@ -53,8 +55,10 @@
 #'   will be empty. This argument can be the same file as `stdout`,
 #'   in which case they will be correctly interleaved. If this is the
 #'   string `"2>&1"`, then standard error is redirected to standard output.
-#'   IF `NULL` (the default), then standard output is not returned, but
+#'   IF `NULL`, then standard output is not returned, but
 #'   it is recorded and included in the error object if an error happens.
+#'   Various special values for this argument such as `"|"` are explained
+#'   in the `stdout` argument of [processx::process].
 #' @param error What to do if the remote process throws an error.
 #'   See details below.
 #' @param poll_connection Whether to have a control connection to

--- a/man/r.Rd
+++ b/man/r.Rd
@@ -88,8 +88,10 @@ If the child process runs with the \code{--slave} option (the default),
 then the commands are not echoed and will not be shown
 in the standard output. Also note that you need to call \code{print()}
 explicitly to show the output of the command(s).
-IF \code{NULL} (the default), then standard output is not returned, but
-it is recorded and included in the error object if an error happens.}
+IF \code{NULL}, then standard output is not returned, but
+it is recorded and included in the error object if an error happens.
+Various special values for this argument such as \code{"|"} are explained
+in the \code{stdout} argument of \link[processx:process]{processx::process}.}
 
 \item{stderr}{The name of the file the standard error of
 the child R process will be written to.
@@ -98,8 +100,10 @@ error. If nothing was sent to the standard error, then this file
 will be empty. This argument can be the same file as \code{stdout},
 in which case they will be correctly interleaved. If this is the
 string \code{"2>&1"}, then standard error is redirected to standard output.
-IF \code{NULL} (the default), then standard output is not returned, but
-it is recorded and included in the error object if an error happens.}
+IF \code{NULL}, then standard output is not returned, but
+it is recorded and included in the error object if an error happens.
+Various special values for this argument such as \code{"|"} are explained
+in the \code{stdout} argument of \link[processx:process]{processx::process}.}
 
 \item{poll_connection}{Whether to have a control connection to
 the process. This is used to transmit messages from the subprocess

--- a/man/r_bg.Rd
+++ b/man/r_bg.Rd
@@ -60,8 +60,10 @@ If the child process runs with the \code{--slave} option (the default),
 then the commands are not echoed and will not be shown
 in the standard output. Also note that you need to call \code{print()}
 explicitly to show the output of the command(s).
-IF \code{NULL} (the default), then standard output is not returned, but
-it is recorded and included in the error object if an error happens.}
+IF \code{NULL}, then standard output is not returned, but
+it is recorded and included in the error object if an error happens.
+Various special values for this argument such as \code{"|"} are explained
+in the \code{stdout} argument of \link[processx:process]{processx::process}.}
 
 \item{stderr}{The name of the file the standard error of
 the child R process will be written to.
@@ -70,8 +72,10 @@ error. If nothing was sent to the standard error, then this file
 will be empty. This argument can be the same file as \code{stdout},
 in which case they will be correctly interleaved. If this is the
 string \code{"2>&1"}, then standard error is redirected to standard output.
-IF \code{NULL} (the default), then standard output is not returned, but
-it is recorded and included in the error object if an error happens.}
+IF \code{NULL}, then standard output is not returned, but
+it is recorded and included in the error object if an error happens.
+Various special values for this argument such as \code{"|"} are explained
+in the \code{stdout} argument of \link[processx:process]{processx::process}.}
 
 \item{poll_connection}{Whether to have a control connection to
 the process. This is used to transmit messages from the subprocess


### PR DESCRIPTION
Some issues I've noticed with the docs for `r` and `r_bg`

* We should really link to https://processx.r-lib.org/reference/process.html#method-new- to explain the special values like `"|"` and `""` 
* [`r_bg`](https://callr.r-lib.org/reference/r_bg.html) inherits its `stderr`/`stdout` docs from `r`, but the default is not `NULL` for that function