### PR TITLE
Make r_process and r_session not cloneable

### DIFF
--- a/R/r-process.R
+++ b/R/r-process.R
@@ -20,6 +20,7 @@
 r_process <- R6::R6Class(
   "r_process",
   inherit = processx::process,
+  cloneable = FALSE,
   public = list(
 
     #' @description

--- a/R/r-session.R
+++ b/R/r-session.R
@@ -33,7 +33,7 @@
 r_session <- R6::R6Class(
   "r_session",
   inherit = processx::process,
-
+  cloneable = FALSE,
   public = list(
 
     #' @field status


### PR DESCRIPTION
Fixes #284 

The dev version of R6 complains about a few other issues in callr -- would you like to make these `finalize()` methods private too? I can update the PR if so.

```
R6Class r_process: finalize() method is public, but it should be private as of R6 2.4.0. This code will continue to work, but in a future version of R6, finalize() will be required to be private.
R6Class r_session: finalize() method is public, but it should be private as of R6 2.4.0. This code will continue to work, but in a future version of R6, finalize() will be required to be private.
R6Class rcmd_process: finalize() method is public, but it should be private as of R6 2.4.0. This code will continue to work, but in a future version of R6, finalize() will be required to be private.
R6Class rscript_process: finalize() method is public, but it should be private as of R6 2.4.0. This code will continue to work, but in a future version of R6, finalize() will be required to be private.
```