### PR TITLE
tests: migrate to testthat mocking

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Imports:
 Suggests:
     asciicast (>= 2.3.1),
     cli (>= 1.1.0),
-    mockery,
     ps,
     rprojroot,
     spelling,

--- a/R/mocks.R
+++ b/R/mocks.R
@@ -1,0 +1,2 @@
+dyn.load <- NULL
+system.file <- NULL

--- a/tests/testthat/test-load-client.R
+++ b/tests/testthat/test-load-client.R
@@ -14,8 +14,7 @@ test_that("load_client_lib", {
 })
 
 test_that("errors", {
-  skip_if_not_installed("mockery")
-  mockery::stub(load_client_lib, "system.file", "")
+  local_mocked_bindings(system.file = function(...) "")
   expect_error(
     load_client_lib(),
     "Cannot find client file"
@@ -23,12 +22,11 @@ test_that("errors", {
 })
 
 test_that("errors 2", {
-  skip_if_not_installed("mockery")
   sofile <- system.file(
     "libs", .Platform$r_arch, paste0("client", .Platform$dynlib.ext),
     package = "processx"
   )
-  mockery::stub(load_client_lib, "dyn.load", function(...) stop("ooops"))
+  local_mocked_bindings(dyn.load = function(...) stop("ooops"))
   expect_error(load_client_lib(sofile))
 })
 


### PR DESCRIPTION
Closes: https://github.com/r-lib/callr/issues/286

Can't really figure out why the oldrel are failing for tests I haven't changed.